### PR TITLE
Open up dependencies and fix clippy issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "marked-yaml"

--- a/marked-yaml/Cargo.toml
+++ b/marked-yaml/Cargo.toml
@@ -16,7 +16,5 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 doc-comment = "0.3"
-# We lock the yaml-rust version down hard for now
-yaml-rust = "=0.4.5"
-# We should keep this in sync with the use from yaml-rust
-linked-hash-map = "=0.5.3"
+yaml-rust = "0.4.5"
+linked-hash-map = "0.5.6"

--- a/marked-yaml/src/loader.rs
+++ b/marked-yaml/src/loader.rs
@@ -60,10 +60,7 @@ use LoaderState::*;
 
 impl LoaderState {
     fn is_error(&self) -> bool {
-        match self {
-            Error(_) => true,
-            _ => false,
-        }
+        matches!(self, Error(_))
     }
 }
 


### PR DESCRIPTION
Hi @kinnison we're using `marked-data` in [`rattler-build`](https://github.com/prefix-dev/rattler-build) and it's working great! Unfortunately we can't publish `rattler-build` to crates.io because we rely on a slightly patched version of `marked-data`.

It would be terrific if you could merge these changes and publish a new version of `marked-data`!

