### PR TITLE
deps: Use hashlink instead of linked-hash-map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,23 +67,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "marked-yaml"
 version = "0.4.0"
 dependencies = [
  "doc-comment",
- "linked-hash-map",
+ "hashlink 0.9.0",
  "serde",
  "serde_path_to_error",
  "yaml-rust2",
@@ -174,7 +177,7 @@ checksum = "498f4d102a79ea1c9d4dd27573c0fc96ad74c023e8da38484e47883076da25fb"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.8.4",
 ]
 
 [[package]]

--- a/marked-yaml/Cargo.toml
+++ b/marked-yaml/Cargo.toml
@@ -22,7 +22,7 @@ serde-path = ["serde", "dep:serde_path_to_error"]
 [dependencies]
 doc-comment = "0.3"
 yaml-rust = { version = "0.8", package = "yaml-rust2" }
-linked-hash-map = "0.5.6"
+hashlink = "0.9.0"
 serde = { version = "1.0.194", optional = true, features = ["derive"] }
 serde_path_to_error = { version = "0.1.16", optional = true }
 

--- a/marked-yaml/src/loader.rs
+++ b/marked-yaml/src/loader.rs
@@ -3,7 +3,7 @@
 
 use crate::types::*;
 
-use linked_hash_map::Entry;
+use hashlink::linked_hash_map::Entry;
 use yaml_rust::parser::{Event, MarkedEventReceiver, Parser};
 use yaml_rust::scanner::Marker as YamlMarker;
 use yaml_rust::scanner::ScanError;

--- a/marked-yaml/src/spanned_serde.rs
+++ b/marked-yaml/src/spanned_serde.rs
@@ -1081,7 +1081,7 @@ impl<'de> Deserializer<'de> for MarkedScalarNodeDeserializer<'de> {
 
 // -------------------------------------------------------------------------------
 
-type MappingValueSeq<'de> = linked_hash_map::Iter<'de, MarkedScalarNode, Node>;
+type MappingValueSeq<'de> = hashlink::linked_hash_map::Iter<'de, MarkedScalarNode, Node>;
 struct MappingAccess<'de> {
     items: Peekable<MappingValueSeq<'de>>,
 }

--- a/marked-yaml/src/types.rs
+++ b/marked-yaml/src/types.rs
@@ -4,10 +4,8 @@
 use doc_comment::doc_comment;
 use hashlink::LinkedHashMap;
 use std::borrow::{Borrow, Cow};
-use std::convert::TryFrom;
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use yaml_rust::Yaml as YamlNode;
 

--- a/marked-yaml/src/types.rs
+++ b/marked-yaml/src/types.rs
@@ -966,7 +966,7 @@ impl MarkedSequenceNode {
     ///
     /// ```
     /// # use marked_yaml::types::*;
-    /// # use linked_hash_map::LinkedHashMap;
+    /// # use hashlink::LinkedHashMap;
     /// # let map: LinkedHashMap<MarkedScalarNode, Node> = LinkedHashMap::new();
     /// let seq: MarkedSequenceNode = vec![map].into_iter().collect();
     /// assert!(seq.get_mapping(0).is_some());
@@ -1056,7 +1056,7 @@ impl MarkedMappingNode {
     ///
     /// ```
     /// # use marked_yaml::types::*;
-    /// # use linked_hash_map::LinkedHashMap;
+    /// # use hashlink::LinkedHashMap;
     /// let node = MarkedMappingNode::new(Span::new_blank(), LinkedHashMap::new());
     /// ```
     pub fn new(span: Span, value: MappingHash) -> Self {

--- a/marked-yaml/src/types.rs
+++ b/marked-yaml/src/types.rs
@@ -2,7 +2,7 @@
 //!
 
 use doc_comment::doc_comment;
-use linked_hash_map::LinkedHashMap;
+use hashlink::LinkedHashMap;
 use std::borrow::{Borrow, Cow};
 use std::convert::TryFrom;
 use std::fmt::{self, Display};


### PR DESCRIPTION
linked-hash-map has been unmaintained for 2 years now and [have some issues](https://github.com/chyh1990/yaml-rust/pull/157#issuecomment-657008824). And most crates are moving to hashlink which provides the same features.