### PR TITLE
fix(serde): support deserializing empty scalars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,6 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
-name = "hashlink"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
@@ -86,7 +77,7 @@ name = "marked-yaml"
 version = "0.7.1"
 dependencies = [
  "doc-comment",
- "hashlink 0.9.0",
+ "hashlink",
  "serde",
  "serde_path_to_error",
  "yaml-rust2",
@@ -171,13 +162,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f4d102a79ea1c9d4dd27573c0fc96ad74c023e8da38484e47883076da25fb"
+checksum = "2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink 0.8.4",
+ "hashlink",
 ]
 
 [[package]]

--- a/marked-yaml/CHANGELOG.md
+++ b/marked-yaml/CHANGELOG.md
@@ -1,0 +1,7 @@
+# marked-yaml changelog
+
+## [Unreleased]
+
+### Bug fixes
+
+* serde: Empty scalars can now be deserialized as a mapping, sequence or unit.

--- a/marked-yaml/Cargo.toml
+++ b/marked-yaml/Cargo.toml
@@ -21,7 +21,7 @@ serde-path = ["serde", "dep:serde_path_to_error"]
 
 [dependencies]
 doc-comment = "0.3"
-yaml-rust = { version = "0.8", package = "yaml-rust2" }
+yaml-rust = { version = "0.9", package = "yaml-rust2" }
 hashlink = "0.9.0"
 serde = { version = "1.0.194", optional = true, features = ["derive"] }
 serde_path_to_error = { version = "0.1.16", optional = true }

--- a/marked-yaml/src/lib.rs
+++ b/marked-yaml/src/lib.rs
@@ -33,6 +33,7 @@
 #![cfg_attr(
     feature = "serde",
     doc = r#"
+## Serde
 
 Should you so choose, you may use serde to deserialise YAML
 strings directly into structures, any amount of which could be annotated
@@ -51,6 +52,9 @@ assert_eq!(roles["User"].span().start().copied(), Some(Marker::new(0, 2, 7)));
 
 You do not have to have all values [`Spanned`], and you can deserialize from an already
 parsed set of nodes with [`from_node`] instead.
+
+Empty scalars can be deserialized to empty sequences, maps, the unit type `()`
+and structs with a `#[serde(default)]` attribute.
 "#
 )]
 #![deny(missing_docs)]

--- a/marked-yaml/src/types.rs
+++ b/marked-yaml/src/types.rs
@@ -813,6 +813,11 @@ Note: this also applies for deserializing nodes via serde.
             None
         }
     }
+
+    #[cfg(feature = "serde")]
+    pub(crate) fn is_empty_scalar(&self) -> bool {
+        self.value.is_empty() && self.may_coerce
+    }
 }
 
 impl<'a> From<&'a str> for MarkedScalarNode {

--- a/marked-yaml/tests/serde.rs
+++ b/marked-yaml/tests/serde.rs
@@ -137,3 +137,50 @@ fn parse_fails_coerce() {
     assert!(s.starts_with("invalid type: string"));
     assert!(s.contains("expected u8"));
 }
+
+#[test]
+fn empty_scalar_map() {
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct Foo {
+        foo: HashMap<String, usize>,
+    }
+    let _: Foo = from_yaml(0, "foo:").unwrap();
+}
+
+#[test]
+fn empty_scalar_seq() {
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct Foo {
+        foo: Vec<String>,
+    }
+    let _: Foo = from_yaml(0, "foo:").unwrap();
+}
+
+#[test]
+fn empty_scalar_unit() {
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct Foo {
+        foo: (),
+    }
+    let _: Foo = from_yaml(0, "foo:").unwrap();
+}
+
+#[test]
+fn empty_scalar_struct_with_default() {
+    #[allow(dead_code)]
+    #[derive(Default, Debug, Deserialize)]
+    struct Bar {
+        buz: Option<String>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct Foo {
+        #[serde(default)]
+        bar: Bar,
+    }
+    let _: Foo = from_yaml(0, "bar:").unwrap();
+}


### PR DESCRIPTION
Previously attempting to deserialize the value of `foo` in:

    foo:

failed when a mapping, sequence or unit was expected.

Note that this fix depends on a related bug fix in yaml-rust2: https://github.com/Ethiraric/yaml-rust2/pull/37. So that:

    foo: null

or

    foo: ~

can still result in errors when a mapping/sequence/unit is expected.