### PR TITLE
Add character index to Marker

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -55,12 +55,12 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo git trees
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-gits-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-${{ matrix.target }}-${{ steps.rustc.outputs.commit_hash }}-${{ hashFiles('**/Cargo.lock') }}

--- a/marked-yaml/src/lib.rs
+++ b/marked-yaml/src/lib.rs
@@ -47,7 +47,7 @@ let YAML = "Daniel: Author\nUser: Not Author\n";
 let roles: HashMap<Spanned<String>, Spanned<String>> = from_yaml(0, YAML).unwrap();
 
 assert_eq!(roles["Daniel"], "Author");
-assert_eq!(roles["User"].span().start().copied(), Some(Marker::new(0, 2, 7)));
+assert_eq!(roles["User"].span().start().copied(), Some(Marker::new(0, 21, 2, 7)));
 ```
 
 You do not have to have all values [`Spanned`], and you can deserialize from an already

--- a/marked-yaml/tests/character.rs
+++ b/marked-yaml/tests/character.rs
@@ -1,0 +1,44 @@
+//! All the tests in here relate to the ability to get character offsets for things.
+
+#[test]
+fn fix_24_character_offset_works() {
+    let input = r#"# some comment
+
+key:       value   #   another  comment
+"#
+    .to_string();
+
+    let document = marked_yaml::parse_yaml(0, &input).unwrap();
+
+    // With the above shape, we know the document is a mapping, so let's retrieve
+    // the "key" value from it
+
+    let node = document.as_mapping().unwrap().get_scalar("key").unwrap();
+    let span = node.span();
+    eprintln!("{span:?}");
+    eprintln!("{node:?}");
+    let (start, end) = (
+        span.start().unwrap().character(),
+        // Because span.end() isn't reliable for scalar nodes right now,
+        // if there's no end marker, try and synthesise it from the node's value.
+        // This is unreliable because the node might have been folded, or had escaped
+        // characters in it which we won't notice.
+        span.end()
+            .map(marked_yaml::Marker::character)
+            .unwrap_or_else(|| span.start().unwrap().character() + node.as_str().chars().count()),
+    );
+
+    let output = input
+        .chars()
+        .take(start)
+        .chain("new_value".chars())
+        .chain(input.chars().skip(end))
+        .collect::<String>();
+
+    let expected_output = r#"# some comment
+
+key:       new_value   #   another  comment
+"#;
+
+    assert_eq!(output, expected_output);
+}


### PR DESCRIPTION
This adds `.character()` to the `Marker` type and spreads support for it through the codebase.

Unfortunately because of the YAML parser we're using not providing end-markers for scalar nodes, we can't *reliably* solve for #24 yet.
